### PR TITLE
Add tests for many edges that share a vertex.

### DIFF
--- a/bugs_test.go
+++ b/bugs_test.go
@@ -710,6 +710,54 @@ func TestOverlappingSegments(t *T) {
 	}.verify(t)
 }
 
+func TestSharedVertex(t *T) {
+	// Three triangles that share a single vertex.
+	testCases{
+		{
+			op: polyclip.UNION,
+			subject: polyclip.Polygon{
+				{{0, 6}, {5, 5}, {2, 10}},
+				{{4, 0}, {10, 4}, {5, 5}},
+			},
+			clipping: polyclip.Polygon{
+				{{5, 5}, {10, 8}, {8, 10}},
+			},
+			result: polyclip.Polygon{{
+				{0, 6}, {5, 5}, {4, 0}, {10, 4}, {5, 5}, {10, 8}, {8, 10}, {5, 5}, {2, 10},
+			}},
+		},
+		{
+			// With vertical edges
+			op: polyclip.UNION,
+			subject: polyclip.Polygon{
+				{{0, 6}, {5, 5}, {5, 10}},
+				{{5, 0}, {10, 4}, {5, 5}},
+			},
+			clipping: polyclip.Polygon{
+				{{5, 5}, {10, 8}, {8, 10}},
+			},
+			result: polyclip.Polygon{{
+				{0, 6}, {5, 5}, {5, 0}, {10, 4}, {5, 5}, {10, 8}, {8, 10}, {5, 5}, {5, 10},
+			}},
+		},
+		{
+			// First triangle to the left of the other two
+			op: polyclip.UNION,
+			subject: polyclip.Polygon{
+				{{0, 6}, {5, 5}, {2, 10}},
+				{{6, 0}, {10, 4}, {5, 5}},
+			},
+			clipping: polyclip.Polygon{
+				{{5, 5}, {10, 8}, {8, 10}},
+			},
+			result: polyclip.Polygon{
+				{{0, 6}, {5, 5}, {2, 10}},
+				{{5, 5}, {10, 4}, {6, 0}, {5, 5}, {8, 10}, {10, 8}},
+			},
+		},
+	}.verify(t)
+}
+
 func TestNonReductiveSegmentDivisions(t *T) {
 	if Short() {
 		return


### PR DESCRIPTION
This is noted as a "special case" in the updated (2013) version of the algorithm. Adding tests for this case facilitate upgrading to that version.